### PR TITLE
fix multiple definition of _PDCLIB_errno_texts

### DIFF
--- a/include/libk/_PDCLIB_int.h
+++ b/include/libk/_PDCLIB_int.h
@@ -425,4 +425,4 @@ int * _PDCLIB_errno_func( void );
 #define _PDCLIB_EMAX 7
 
 /* TODO: Doing this via a static array is not the way to do it. */
-char const * _PDCLIB_errno_texts[ _PDCLIB_EMAX ];
+extern char const * _PDCLIB_errno_texts[ _PDCLIB_EMAX ];


### PR DESCRIPTION
Im not sure if it's the way to go.