### PR TITLE
Actual fix for multiple definition of _PDCLIB_errno_texts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,10 +213,10 @@ install(FILES
 	${CMAKE_SOURCE_DIR}/include/libk/stdlib.h
 	${CMAKE_SOURCE_DIR}/include/libk/string.h
 	${CMAKE_SOURCE_DIR}/include/_PDCLIB_config.h
-	DESTINATION include/libk
+	DESTINATION $ENV{VITASDK}/arm-vita-eabi/include/libk
 )
 
 install(TARGETS k
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION $ENV{VITASDK}/arm-vita-eabi/lib
+	ARCHIVE DESTINATION $ENV{VITASDK}/arm-vita-eabi/lib
 )

--- a/include/libk/_PDCLIB_int.h
+++ b/include/libk/_PDCLIB_int.h
@@ -425,4 +425,4 @@ int * _PDCLIB_errno_func( void );
 #define _PDCLIB_EMAX 7
 
 /* TODO: Doing this via a static array is not the way to do it. */
-char const * _PDCLIB_errno_texts[ _PDCLIB_EMAX ];
+extern char const * _PDCLIB_errno_texts[ _PDCLIB_EMAX ];

--- a/thirdparty/pdclib/internals/_PDCLIB_int.h
+++ b/thirdparty/pdclib/internals/_PDCLIB_int.h
@@ -425,4 +425,4 @@ int * _PDCLIB_errno_func( void );
 #define _PDCLIB_EMAX 7
 
 /* TODO: Doing this via a static array is not the way to do it. */
-char const * _PDCLIB_errno_texts[ _PDCLIB_EMAX ];
+extern char const * _PDCLIB_errno_texts[ _PDCLIB_EMAX ];


### PR DESCRIPTION
Actual fix for multiple definition of _PDCLIB_errno_texts + fixed cmake install paths